### PR TITLE
Fix fetch_image()

### DIFF
--- a/src/ImageCache/ImageCache.php
+++ b/src/ImageCache/ImageCache.php
@@ -224,7 +224,7 @@ class ImageCache
 	        imagealphablending( $image_dest, false );
 	        imagesavealpha( $image_dest, true );
 		}
-		imagecopy( $image_dest, $image_src, 0, 0, 0, 0, $image_width, $image_width );
+		imagecopy( $image_dest, $image_src, 0, 0, 0, 0, $image_width, $image_height );
 		switch( $file_mime_as_ext ) {
 			case 'jpeg':
 				$created = imagejpeg( $image_dest, $this->cached_filename, 85 );


### PR DESCRIPTION
Because when the image has a longer height than width, the image is created with a blank space until the height ends.

Original Image
![poltronas-original](https://cloud.githubusercontent.com/assets/9197817/5663546/8d697794-972f-11e4-8ebe-c556eb28fe81.jpg)

Image after cache();
![poltronas-php-mage-cache](https://cloud.githubusercontent.com/assets/9197817/5663547/8d6b1de2-972f-11e4-9e05-a68b8027479e.jpeg)
