### PR TITLE
Updated for PHP 8.0+

### DIFF
--- a/demo/index.php
+++ b/demo/index.php
@@ -19,8 +19,12 @@
 	<?php
 		$imagecache = new ImageCache\ImageCache();
 		$imagecache->cached_image_directory = dirname(__FILE__) . '/images/cached';
-
+		// Test one with local file, also the same behavior as a file upload via PHP POST
 		$cached_src_one = $imagecache->cache( 'images/unsplash1.jpeg' );
+		// Show new cached filepath
+		echo '<p>Image Path: ' . $cached_src_one . '</p>';
+		// Show source filepath
+		echo '<p>Image Details: src - ' . $imagecache->image_src . ' filename - ' .  $imagecache->cached_filename . '</p>';
 		echo '<p>Original file size: ' . filesize($imagecache->image_src) . ' bytes</p>';
 		echo '<p>PHPImageCach-ified file size: ' . filesize($imagecache->cached_filename) . ' bytes</p>';
 		echo '<p>Total image size reduction: ' . (((filesize($imagecache->image_src) - filesize($imagecache->cached_filename)) / filesize($imagecache->image_src))*100) . '%</p>';
@@ -28,7 +32,7 @@
 	<img src="<?php echo $cached_src_one; ?>" alt="">
 	<hr>
 	<?php
-		$imagecache->check_link_cached = false;
+		// Test another local file
 		$cached_src_two = $imagecache->cache( 'images/unsplash2.jpeg' );
 		echo '<p>Original file size: ' . filesize($imagecache->image_src) . ' bytes</p>';
 		echo '<p>PHPImageCach-ified file size: ' . filesize($imagecache->cached_filename) . ' bytes</p>';
@@ -37,13 +41,13 @@
 	<img src="<?php echo $cached_src_two; ?>" alt="">
 	<hr>
 	<?php
-		$cached_src_two = $imagecache->cache( 'http://placehold.it/350x350' );
+		// Test downloading remote file
+		$cached_src_three = $imagecache->cache( 'https://cdn.pixabay.com/photo/2015/04/23/22/00/tree-736885_960_720.jpg' );
 		echo 'Original file size: ' . filesize($imagecache->image_src) . ' bytes<br>';
 		echo 'PHPImageCach-ified file size: ' . filesize($imagecache->cached_filename) . ' bytes<br>';
-		echo 'Total image size reduction: ' . (((filesize($imagecache->image_src) - filesize($imagecache->cached_filename)) / filesize($imagecache->image_src))*100) . '%';
+		echo 'Total image size reduction: ' . (((filesize($imagecache->image_src) - filesize($imagecache->cached_filename)) / filesize($imagecache->image_src))*100) . '%</p>';
 	?>
-	<p>Because the "compressed" file size is larger than the original, a local copy of the original file will be server instead.</p>
-	<img src="<?php echo $cached_src_two; ?>" alt="">
+	<img src="<?php echo $cached_src_three; ?>" alt="">
 
 </body>
 </html>

--- a/src/ImageCache/ImageCache.php
+++ b/src/ImageCache/ImageCache.php
@@ -165,7 +165,7 @@ class ImageCache {
      * @return string The source file to be referenced after compressing an image
      */
     public function cache($image, $version = "") {
-ob_start();
+		ob_start();
         if ( ! is_writable($this->cached_image_directory))
             $this->error( $this->cached_image_directory . ' must writable!');
 
@@ -176,7 +176,7 @@ ob_start();
         $this->image_src_version = $version;
         $this->pre_set_class_vars();
 
-        // If the image hasn't been server up at this point, fetch, compress, cache, and return
+        // If the image hasn't been served up at this point, fetch, compress, cache, and return
         if ($this->cached_file_exists()) {
             $this->src_filesize = filesize($this->image_src);
             $this->cached_filesize = filesize($this->cached_filename);
@@ -193,6 +193,8 @@ ob_start();
         if (!$this->fetch_image())
             $this->error('Could not copy image resource.');
         $this->src_filesize = filesize($this->image_src);
+        // Delete the temporary source picture because imagedestroy() is no longer capable in PHP 8.0+
+        unlink($this->image_src);
         $this->cached_filesize = filesize($this->cached_filename);
         if ($this->src_filesize < $this->cached_filesize) {
             ob_end_clean();
@@ -207,7 +209,7 @@ ob_start();
      */
     private function download_image() {
         $image_resource = file_get_contents($this->image_src);
-        $basename = basename($this->image_src);
+		$basename = basename($this->image_src);
         if (!stripos($basename, '.' . $this->file_extension)) {
             $basename .= '.' . $this->file_extension;
         }
@@ -287,8 +289,8 @@ ob_start();
                 return false;
                 break;
         }
-        imagedestroy($image_src);
-        imagedestroy($image_dest);
+        unset($image_src);
+        unset($image_dest);
         $this->reset_memory_limit();
         return $created;
     }


### PR DESCRIPTION
Removed imagedestroy() calls, replaced with unset() and added unlink() to destroy the temporary file after processing